### PR TITLE
feat: agregar formulario de recetas en diario.html 

### DIFF
--- a/EasyMeal/css/diario/styles.css
+++ b/EasyMeal/css/diario/styles.css
@@ -248,3 +248,206 @@ html, body {
 }
 
 
+/*FORM*/
+/* Fondo oscuro del modal */
+#modal {
+  display: none; /* Oculto por defecto */
+  position: fixed;
+  z-index: 1000; /* Muy por encima del resto */
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Fondo oscuro transparente */
+  justify-content: center;
+  align-items: center;
+}
+
+/* Contenedor del formulario dentro del modal */
+#modal-content {
+  background-color: #fff;
+  padding: 24px;
+  border-radius: 12px;
+  width: 800px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+#modal-content h3 {
+  margin-top: 0;
+}
+
+#modal-content input,
+#modal-content textarea {
+  width: 100%;
+  margin: 10px 0;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+#modal-content button {
+  margin-top: 10px;
+  padding: 8px 14px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#modal-content .cancelar {
+  background-color: #ccc;
+}
+
+#modal-content .guardar {
+  background-color: #4CAF50;
+  color: white;
+  margin-left: 10px;
+}
+
+#formulario {
+  display: none;
+  background-color: #fff;
+  padding: 20px;
+  border: 2px solid #ccc;
+  border-radius: 12px;
+  width: 400px;
+  margin: 20px auto;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+#modal-content input,
+#modal-content textarea {
+  width: 100%;
+  padding: 8px;
+  font-size: 0.85rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-family: 'Poppins', sans-serif;
+  box-sizing: border-box;
+}
+#modal-content textarea:focus {
+  border-color: #4CAF50;
+  outline: none;
+}
+#formulario button {
+  padding: 8px 12px;
+  background-color: #4CAF50;
+  border: none;
+  color: white;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+/*OPCIONES*/
+.opciones {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.opciones label {
+  font-weight: 500;
+  font-size: 0.85 rem;
+}
+
+.opciones select {
+  width: 100%;
+  padding: 8px;
+  font-size: 0.85rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background-color: white;
+  font-family: 'Poppins', sans-serif;
+  box-shadow: none;
+}
+.opciones select:focus {
+  border-color: #4CAF50;
+  outline: none;
+}
+.form-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr; /* 3 columnas iguales */
+  gap: 20px;
+}
+
+.col input,
+.col textarea,
+.col select {
+  width: 100%;
+  padding: 8px;
+  font-size: 0.85rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-family: 'Poppins', sans-serif;
+  box-sizing: border-box;
+  margin-bottom: 12px;
+}
+
+.col label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  margin-bottom: 4px;
+  display: block;
+  color: #333;
+}
+input[type="file"] {
+  font-family: 'Poppins', sans-serif;
+  font-size: 0.8rem;
+  margin-top: 6px;
+}
+
+.col1 label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #333;
+  display: block;
+  margin-bottom: 6px;
+}
+
+/*CONFIRMACIÓN DE SALIR*/
+.confirm-modal {
+  display: none;
+  position: fixed;
+  z-index: 1100;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  justify-content: center;
+  align-items: center;
+}
+
+.confirm-content {
+  background: #fff;
+  padding: 24px;
+  border-radius: 12px;
+  width: 350px;
+  text-align: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.confirm-buttons {
+  margin-top: 20px;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.confirm-buttons button {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  border-radius: 8px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+#confirm-yes {
+  background-color: #4CAF50;
+  color: white;
+}
+
+#confirm-no {
+  background-color: #ccc;
+}

--- a/EasyMeal/diario.html
+++ b/EasyMeal/diario.html
@@ -7,24 +7,108 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500&family=Salsa&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/diario/styles.css" />
   
+ 
 </head>
 <body>
-  <div class="container">
+  <div id="modal">
+    <div id="modal-content">
+      <h3>Nueva receta</h3>
+      <form id="form-receta" enctype="multipart/form-data">
+        <div class="form-columns">
+          <!-- Columna 1 -->
+          <div class="col col1">
+            <label for="imagen">Foto de la receta:</label>
+            <input type="file" id="imagen" accept="image/*">
+            <img id="preview" src="#" alt="Vista previa" style="display: none; width: 100%; border-radius: 10px; margin-top: 10px;" />
+            <label for="nivel">Nivel de la receta:</label>
+            <select id="nivel" required>
+              <option disabled selected hidden>Selecciona un nivel</option>
+              <option value="Fácil">Fácil</option>
+              <option value="Intermedio">Intermedio</option>
+              <option value="Master Chef">Master Chef</option>
+            </select>
 
+          </div>
+
+          <!-- Columna 2 -->
+          <div class="col col2">
+            <label for="titulo">Título de la receta:</label>
+            <textarea id="titulo" placeholder="Título de la receta"  required></textarea>
+
+            <label for="nota">Nota o comentario:</label>
+            <textarea id="nota" placeholder="Nota o comentario" rows="4" required></textarea>
+          </div>
+
+          <!-- Columna 3 -->
+          <div class="col col3 opciones">
+            <label for="resultado">Resultado:</label>
+            <select id="resultado" required>
+              <option disabled selected hidden>Selecciona una opción</option>
+              <option value="Me encantó">Me encantó</option>
+              <option value="Quedó bien">Quedó bien</option>
+              <option value="Aceptable">Aceptable</option>
+              <option value="No me salió">No me salió</option>
+            </select>
+
+            <label for="dificultad">Dificultad:</label>
+            <select id="dificultad" required>
+              <option disabled selected hidden>Selecciona una opción</option>
+              <option value="Súper fácil">Súper fácil</option>
+              <option value="Fácil de seguir">Fácil de seguir</option>
+              <option value="Intermedia">Intermedia</option>
+              <option value="Un poco difícil">Un poco difícil</option>
+              <option value="Muy difícil">Muy difícil</option>
+            </select>
+
+            <label for="presentacion">Presentación:</label>
+            <select id="presentacion" required>
+              <option disabled selected hidden>Selecciona una opción</option>
+              <option value="Muy bonita">Muy bonita</option>
+              <option value="Bonita">Bonita</option>
+              <option value="Normal">Normal</option>
+              <option value="Podría mejorar">Podría mejorar</option>
+              <option value="Fea">Fea</option>
+            </select>
+
+            <label for="tiempo">Tiempo:</label>
+            <select id="tiempo" required>
+              <option disabled selected hidden>Selecciona una opción</option>
+              <option value="Rápido">Rápido</option>
+              <option value="En el tiempo previsto">En el tiempo previsto</option>
+              <option value="Muy demorado">Muy demorado</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Botones -->
+        <div style="text-align: right; margin-top: 20px;">
+          <button type="button" class="cancelar" onclick="cerrarModal()">Cancelar</button>
+          <button type="submit" class="guardar">Guardar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  
+  <div id="confirm-modal" class="confirm-modal">
+    <div class="confirm-content">
+      <p>¿Estás seguro de que quieres salir? Se perderán los cambios.</p>
+      <div class="confirm-buttons">
+        <button id="confirm-yes">Sí, salir</button>
+        <button id="confirm-no">Cancelar</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
     <!-- Sidebar -->
      
     <div class="sidebar">
       <div class="menu">
-        <a href="Menu.html">
-         <button><img src="assets/diario/icons/Home.png" alt="Ir a página"></button>
-        </a>
+        <button><img src="assets/diario/icons/Home.png" alt=""></button>
         <button><img src="assets/diario/icons/Comida rápida.png" alt=""></button>
         <button><img src="assets/diario/icons/Calendario.png" alt=""></button>
         <button><img src="assets/diario/icons/Favoritos.png" alt=""></button>
-        <a href="diario.html">
-          <button><img src="assets/diario/icons/Libreto.png" alt=""></button>
-        </a>
-        
+        <button><img src="assets/diario/icons/Libreto.png" alt=""></button>
         <button><img src="assets/diario/icons/Exit.jpg" alt=""></button>
       </div>
     </div>
@@ -33,7 +117,7 @@
 
     <div class="content">
       <div class="logo">
-        <img src="assets/diario//icons/easymeal_logo.png" alt="EasyMeal Logo">
+        <img src="assets/diario/icons/easymeal_logo.png" alt="EasyMeal Logo">
         <span class="easymeal-title">EasyMeal</span>
         <div class="header-right">
           <button><img src="assets/diario/icons/Notificación.png" alt="Notificación"></button>
@@ -194,5 +278,127 @@
           </div>
         </div>
       </div>
+    <div id="formulario">
+  <h3>Agregar Receta</h3>
+  <form>
+    <input type="text" placeholder="Título de la receta" required>
+    <textarea placeholder="Nota o comentario" rows="4" required></textarea>
+    <button type="submit">Guardar</button>
+    <button type="button" onclick="document.getElementById('formulario').style.display='none'">Cancelar</button>
+  </form>
+</div>
+  <script>
+
+    const modal = document.getElementById("modal");
+    const botonAbrir = document.querySelector(".add-button");
+    const formulario = document.querySelector("#modal-content form");
+
+    botonAbrir.addEventListener("click", () => {
+      formulario.reset(); // Limpiar campos
+      const preview = document.getElementById("preview");
+      if (preview) preview.style.display = "none"; // Ocultar imagen si estaba cargada
+      modal.style.display = "flex"; // Mostrar modal
+    });
+
+
+    function cerrarModal() {
+      document.getElementById("confirm-modal").style.display = "flex";
+    }
+
+    // Botones del modal de confirmación
+    document.getElementById("confirm-yes").addEventListener("click", () => {
+      document.getElementById("modal").style.display = "none";
+      document.getElementById("confirm-modal").style.display = "none";
+    });
+
+    document.getElementById("confirm-no").addEventListener("click", () => {
+      document.getElementById("confirm-modal").style.display = "none";
+    });
+
+
+
+    // También permite cerrar al hacer clic fuera del modal
+    window.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        cerrarModal();
+      }
+    });
+
+    const inputImagen = document.getElementById("imagen");
+    const preview = document.getElementById("preview");
+
+    inputImagen.addEventListener("change", () => {
+      const file = inputImagen.files[0];
+      if (file) {
+        preview.src = URL.createObjectURL(file);
+        preview.style.display = "block";
+      }
+    });
+
+    document.getElementById("form-receta").addEventListener("submit", function (e) {
+      e.preventDefault(); // Prevenir que se recargue la página
+
+      const titulo = document.getElementById("titulo").value;
+      const nota = document.getElementById("nota").value;
+      const nivel = document.getElementById("nivel").value;
+      const resultado = document.getElementById("resultado").value;
+      const dificultad = document.getElementById("dificultad").value;
+      const presentacion = document.getElementById("presentacion").value;
+      const tiempo = document.getElementById("tiempo").value;
+      const imagenInput = document.getElementById("imagen");
+      const imagenArchivo = imagenInput.files[0];
+
+      if (
+        resultado === "Selecciona una opción" ||
+        dificultad === "Selecciona una opción" ||
+        presentacion === "Selecciona una opción" ||
+        tiempo === "Selecciona una opción" ||
+        nivel === "Selecciona un nivel"
+      ) {
+        alert("Por favor, completa todos los campos antes de guardar.");
+        return; // No continúa si falta algo
+      }
+
+      const reader = new FileReader();
+
+      reader.onload = function (event) {
+        const recetaHTML = `
+          <div class="recipe-card">
+            <img src="${event.target.result}" alt="${titulo}" />
+            <div class="recipe-content">
+              <div class="badge">${nivel}</div>
+              <div class="title">${titulo.toUpperCase()}</div>
+              <div class="nota">NOTA: ${nota}</div>
+              <div class="tags">
+                <span>${resultado.toUpperCase()}</span>
+                <span>${dificultad.toUpperCase()}</span>
+                <span>${presentacion.toUpperCase()}</span>
+                <span>${tiempo.toUpperCase()}</span>
+              </div>
+            </div>
+          </div>
+        `;
+
+        const contenedor = document.querySelector(".recipe-grid");
+        contenedor.insertAdjacentHTML("beforeend", recetaHTML);
+
+        // Cierra el modal y limpia el formulario
+        modal.style.display = "none";
+        document.getElementById("form-receta").reset();
+        const preview = document.getElementById("preview");
+        if (preview) preview.style.display = "none";
+      };
+
+      if (imagenArchivo) {
+        reader.readAsDataURL(imagenArchivo); // Carga imagen
+      } else {
+        alert("Por favor selecciona una imagen");
+      }
+    });
+
+  </script>
 </body>
+
 </html>
+
+


### PR DESCRIPTION
- Se implementó un formulario en diario.html para agregar nuevos registros de recetas, con estilos personalizados definidos en css/diario/styles.css.

- Se controlaron los eventos del formulario y se añadieron los campos necesarios: subida de imagen, selección de nivel, nombre de la receta, nota personal y etiquetas.
 
- Las nuevas entradas se integran visualmente junto al resto de recetas existentes.